### PR TITLE
add missing boolean variable persist in get_data line 810

### DIFF
--- a/ztfimg/science.py
+++ b/ztfimg/science.py
@@ -808,7 +808,7 @@ class ScienceCCD(CCD, ComplexImage):
         return self.get_data(calling="get_mask", **kwargs)
     
     def get_data(self, apply_mask=False,
-                     rm_bkgd=False, 
+                     rm_bkgd=False, persist=False,
                      rebin=None, rebin_stat="mean",
                      maskvalue=np.NaN,
                      zp=None,


### PR DESCRIPTION
in science.py
missing boolean was preventing get_data() to work for instance notebook "quadrand ccd focalplane"