### PR TITLE
`corr_pocket` option from `ztfimg.raw.RawQuadrant.get_data` takes optional parameters for PocketModel

### DIFF
--- a/ztfimg/base.py
+++ b/ztfimg/base.py
@@ -24,9 +24,9 @@ def read_header(filepath, ext=None, use_dask=False, persist=False):
 
     use_dask: bool
         should this use dask ?
-        
+
     persist: bool
-        = ignored if use_dask=False = 
+        = ignored if use_dask=False =
         should the returned delayed object be persisted ?
 
     Returns
@@ -44,23 +44,23 @@ def read_header(filepath, ext=None, use_dask=False, persist=False):
         header = fits.getheader(filepath, ext)
     return header
 
-    
+
 class Image( object ):
     SHAPE = None
     # Could be any type (raw, science)
 
     def __init__(self, data=None, header=None):
-        """  
+        """
         See also
         --------
-        from_filename: load the instance given a filename 
+        from_filename: load the instance given a filename
         from_data: load the instance given its data (and header)
-        
+
         """
         if data is not None:
             # this updates use_dask
             self.set_data(data)
-            
+
         if header is not None:
             self.set_header(header)
 
@@ -71,7 +71,7 @@ class Image( object ):
 
         if "dask" in str( type(filepath) ):
             use_dask = True
-    
+
         if use_dask:
             # - Data
             data = da.from_delayed( dask.delayed( getdata) (filepath, ext=ext),
@@ -90,14 +90,14 @@ class Image( object ):
         if "dask" in str( type(filepath) ):
             use_dask = True
 
-        header = read_header(filepath, use_dask=use_dask, persist=persist, ext=ext)            
+        header = read_header(filepath, use_dask=use_dask, persist=persist, ext=ext)
         return header
 
     @staticmethod
     def _to_fits(fileout, data, header=None,  overwrite=True,
                      **kwargs):
         """ """
-        import os        
+        import os
         from astropy.io import fits
         dirout = os.path.dirname(fileout)
         if dirout not in ["","."] and not os.path.isdir(dirout):
@@ -106,16 +106,16 @@ class Image( object ):
         fits.writeto(fileout, data, header=header,
                          overwrite=overwrite, **kwargs)
         return fileout
-    
+
     @staticmethod
     def _get_filepath(filename, as_path=True, use_dask=False, **kwargs):
         """ internal function that can call ztfquery.get_file() to download files you don't have yet.
-        
+
         Parameters
         ----------
         as_path: bool
             is the into filename the full path (so nothing to do)
-        
+
         use_dask: bool
             = only applies if as_path is False =
             this using ztfquery.get_file(). Should this be delayed ?
@@ -128,7 +128,7 @@ class Image( object ):
         """
         if as_path:
             return filename
-        
+
         from ztfquery import io
         # Look for it
         prop = dict(show_progress=False, maxnprocess=1)
@@ -138,7 +138,7 @@ class Image( object ):
             filename  = io.get_file(filename, **prop)
 
         return filename
-    
+
     @classmethod
     def from_filename(cls, filename,
                           as_path=True,
@@ -150,15 +150,15 @@ class Image( object ):
         ----------
         filename: str
             fullpath or filename or the file to load.
-            If a filename is given, set as_path=False,  then ztfquery.get_file() 
+            If a filename is given, set as_path=False,  then ztfquery.get_file()
             will be called to grab the file for you (and download it if necessary)
-            
+
         as_path: bool
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
-        
+
         use_dask: bool, optional
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool, optional
@@ -170,25 +170,25 @@ class Image( object ):
 
         **kwargs: goes to __init__()
 
-        
+
         Returns
         -------
-        class instance 
-        
+        class instance
+
         Examples
         --------
         Load a ztf image you know the name of but not the full path.
-        
+
         >>> img = Image.from_filename("ztf_20220704387176_000695_zr_c11_o_q3_sciimg.fits", as_path=False, use_dask=False)
-        
+
         """
         if not use_dask:
             dask_header = False
-            
+
         filepath = cls._get_filepath(filename, as_path=as_path, use_dask=use_dask)
         data = cls._read_data(filepath, use_dask=use_dask, persist=persist)
         header = cls._read_header(filepath, use_dask=dask_header, persist=persist)
-        
+
         # self
         this = cls.from_data(data=data, header=header, **kwargs)
         this._filename = filename
@@ -197,8 +197,8 @@ class Image( object ):
 
     @classmethod
     def from_data(cls, data, header=None, **kwargs):
-        """ Instanciate this class given data. 
-        
+        """ Instanciate this class given data.
+
 
         Parameters
         ----------
@@ -214,7 +214,7 @@ class Image( object ):
         Returns
         -------
         class instance
-        
+
         """
         return cls(data=data, header=header, **kwargs)
 
@@ -230,7 +230,7 @@ class Image( object ):
             if fileout already exists, shall this overwrite it ?
 
         **kwargs goes to astropy.fits.writeto()
-        
+
         Returns
         -------
         str
@@ -238,7 +238,7 @@ class Image( object ):
         """
         return self._to_fits(fileout, data=self.data, header=self.header,
                                 overwrite=overwrite, **kwargs)
-    
+
     # -------- #
     #  SETTER  #
     # -------- #
@@ -250,12 +250,12 @@ class Image( object ):
         """ Set the data to the instance
 
         = It is unlikely you need to use that directly. =
-        
+
         Parameters
         ----------
         data: numpy.array, dask.array
             numpy or dask array with the same shape as cls.shape.
-        
+
         Returns
         -------
         None
@@ -263,13 +263,13 @@ class Image( object ):
         Raises
         ------
         ValueError
-            This error is returned if the shape is not matching 
-        
+            This error is returned if the shape is not matching
+
         See also
         --------
         from_filename: loads the instance (data, header) given a filepath
         from_data: loads the instance given data and header.
-        
+
         """
         if self.shape is not None and ((dshape:=data.shape) != self.shape).any():
             raise ValueError(f"shape of the input CCD data must be {self.shape} ; {dshape} given")
@@ -278,15 +278,15 @@ class Image( object ):
         used_dask = "dask" in str(type(data))
         if self.use_dask is not None and used_dask != self.use_dask:
             warnings.warn(f"Input data and self.use_dask are not compatible. Now: use_dask={used_dask}")
-            
+
         self._use_dask = used_dask
         self._data = data
-        
+
     # -------- #
     #  GETTER  #
     # -------- #
     def get_data(self, rebin=None, rebin_stat="nanmean", data=None):
-        """ get image data 
+        """ get image data
 
         Parameters
         ----------
@@ -317,10 +317,10 @@ class Image( object ):
             dask or numpy array, which shape will depend on rebin
         """
         npda = da if self.use_dask else np
-        
+
         if data is None:
             data = "data"
-            
+
         if rebin is not None and rebin <= 1:
             warnings.warn("rebin <=1 does not make sense. rebin set to None")
             rebin = None
@@ -328,7 +328,7 @@ class Image( object ):
         # This is the normal case
         if self.has_data() and rebin is None and data=="data":
             data_ = self.data.copy()
-        
+
         else:
             if type(data) == str:
                 if data == "data":
@@ -338,7 +338,7 @@ class Image( object ):
                 else:
                     raise ValueError(
                         f"value as string can only be 'data' or a known attribute ; {data} given")
-                
+
             elif type(data) in [int, float]:
                 data_ = npda.ones(self.shape) * data
             else:
@@ -363,21 +363,21 @@ class Image( object ):
         """
         if "dask" in str( type( self.header) ) and compute:
             return self.header.compute()
-        
+
         return self.header
 
     def get_value(self, key, default=None, attr_ok=True):
         """ quick access to an image value.
-        
+
         This method looks for this key in:
         1. image's attributes
         2. image's meta
         3. image's header (using upper case).
-        
+
         Parameters
         ----------
         key: str
-            entry of the header. 
+            entry of the header.
 
         default: None, float, str
             what is returned if the entry cannot be found in the header.
@@ -392,14 +392,14 @@ class Image( object ):
 
         Raises
         ------
-        AttributeError 
+        AttributeError
             If no header is set this returns is returned
         """
         key_ = key.lower()
         # Is that a local attribute ?
         if attr_ok and hasattr(self, key_):
             return getattr(self, key_)
-        
+
         # Look for meta then
         key_ = key.lower()
         _CONVERTION = {"fieldid":"field",
@@ -407,7 +407,7 @@ class Image( object ):
                        "filtername": "filtercode",
                         }
         key_ = _CONVERTION.get(key_,key_)
-        
+
         meta = self.meta
         if meta is not None and key_ in meta:
             return meta[key_]
@@ -418,12 +418,12 @@ class Image( object ):
 
         # header so upper case:
         key_ = key.upper()
-        
+
         # keep all in upper case
         _HEADER_KEY = {"CCDID": "CCD_ID",
                         "FILTERCODE": "FILTER"}
         key_ = _HEADER_KEY.get(key_, key_) # update
-        
+
         return self.header.get(key_, default)
 
     def get_aperture(self, x, y, radius,
@@ -443,19 +443,19 @@ class Image( object ):
 
         radius: float, list
             size (radius) of the aperture. This could be a list of radius.
-            
+
         data: 2d-array, None
             if you want to apply the aperture photometry on this specific image, provide it.
             otherwhise, ``data = self.get_data()`` is used
-            
+
         bkgann: 2d-array, None
             inner and outer radius of a “background annulus”.
-            If supplied, the background is estimated by averaging 
+            If supplied, the background is estimated by averaging
             unmasked pixels in this annulus.
 
         subpix: int
             Subpixel sampling factor. 0 is the exact overlap calculation ; 5 is acceptable.
-            
+
         err: 2d-array, None
             error image if you have it.
 
@@ -467,7 +467,7 @@ class Image( object ):
             If As DataFrame, this will be a dataframe with
             3xn-radius columns (f_0...f_i, f_0_e..f_i_e, f_0_f...f_i_f)
             standing for fluxes, errors, flags.
-            
+
         Returns
         -------
         2d-array or dataframe
@@ -479,7 +479,7 @@ class Image( object ):
 
         >>> import ztfimg
         >>> import numpy as np
-        >>> img = ztfimg.Quadrant.from_filename("ztf_20220704387176_000695_zr_c11_o_q3_sciimg.fits", as_path=False, 
+        >>> img = ztfimg.Quadrant.from_filename("ztf_20220704387176_000695_zr_c11_o_q3_sciimg.fits", as_path=False,
                                     use_dask=False)
         >>> x = np.random.uniform(0, ztfimg.Quadrant.shape[1], size=400)
         >>> y = np.random.uniform(0, ztfimg.Quadrant.shape[0], size=400)
@@ -487,7 +487,7 @@ class Image( object ):
         >>> df = img.get_aperture(x,y, radius=radius[:,None], as_dataframe=True)
         >>> df.shape
         (400, 30) # 30 because 10 radius, so 10 flux, 10 errors, 10 flags
-         
+
         """
         if data is None:
             data = self.get_data()
@@ -508,7 +508,7 @@ class Image( object ):
                      as_dataframe=False,
                      **kwargs):
         """  get the apeture photometry, base on `sep.sum_circle()`
-        = Internal method = 
+        = Internal method =
 
         Parameters
         ----------
@@ -521,17 +521,17 @@ class Image( object ):
 
         radius: float, list
             size (radius) of the aperture. This could be a list of radius.
-            
+
         bkgann: 2d-array, None
             inner and outer radius of a “background annulus”.
-            If supplied, the background is estimated by averaging 
+            If supplied, the background is estimated by averaging
             unmasked pixels in this annulus. If supplied, the inner
             and outer radii obey numpy broadcasting rules along with ``x``,
             ``y`` and ``r``.
 
         subpix: int
             Subpixel sampling factor. 0 is the exact overlap calculation ; 5 is acceptable.
-            
+
         err: 2d-array, None
             error image if you have it.
 
@@ -559,7 +559,7 @@ class Image( object ):
                               x, y, radius=radius,
                               err=err, mask=mask, bkgann=bkgann,
                               use_dask=use_dask, **kwargs)
-        
+
         if not as_dataframe:
             return apdata
 
@@ -576,7 +576,7 @@ class Image( object ):
                                       columns=dic.keys())
 
         return pandas.DataFrame(dic)
-        
+
     # -------- #
     # PLOTTER  #
     # -------- #
@@ -602,25 +602,25 @@ class Image( object ):
 
         apply: str, None
             provide a numpy method that should be applied to the data
-            prior been shown. 
+            prior been shown.
             For instance, apply="log10", then np.log10(data) will be shown.
-            
+
         data: 2d-array, None
             if you want to plot this specific image, provide it.
             otherwhise, ``data = self.get_data(rebin=rebin)`` is shown.
 
         vmin, vmax: str, float
             minimum and maximum value for the colormap.
-            string are interpreted as 'percent of data'. 
+            string are interpreted as 'percent of data'.
             float or int are understood as 'use as such'
 
         rebin: int, None
             by how much should the data be rebinned when accessed ?
             (see details in get_data())
-            
+
         savefile: str, None
             if you want to save the plot, provide here the path for that.
-        
+
         dpi: int
             = ignored if savefile is None =
             dpi of the stored image
@@ -635,7 +635,7 @@ class Image( object ):
         get_data: acess the image data
         """
         if ax is None:
-            import matplotlib.pyplot as plt            
+            import matplotlib.pyplot as plt
             fig = plt.figure(figsize=[5 + (1.5 if colorbar else 0), 5])
             ax = fig.add_subplot(111)
         else:
@@ -643,7 +643,7 @@ class Image( object ):
 
         if data is None:
             data = self.get_data(rebin=rebin)
-            
+
         if "dask" in str( type(data) ):
             data = data.compute()
 
@@ -670,15 +670,15 @@ class Image( object ):
         """ are the data dasked (did you set use_dask=True) """
         if not hasattr(self, "_use_dask"): # means set_data never called
             return None
-        
+
         return self._use_dask
-    
+
     @property
     def data(self):
         """ data of the image ; numpy.array or dask.array"""
         if not hasattr(self, "_data"):
             return None
-        
+
         return self._data
 
     def has_data(self):
@@ -703,7 +703,7 @@ class Image( object ):
     def filename(self):
         """ If this method was loaded from a file, this is it's filename. None otherwise """
         if not hasattr(self, "_filename"):
-            return self.filepath # could be None 
+            return self.filepath # could be None
         return self._filename
 
     @property
@@ -712,7 +712,7 @@ class Image( object ):
         if not hasattr(self, "_filepath"):
             return None
         return self._filepath
-    
+
 
     @property
     def filtername(self):
@@ -736,7 +736,7 @@ class Image( object ):
             return None
         return self._meta
 
-    
+
 # -------------- #
 #                #
 #   Virtual      #
@@ -746,12 +746,12 @@ class _Collection_( object ):
     _COLLECTION_OF = Image # Set this to None to let it guess
 
     @classmethod
-    def _read_filenames(cls, filenames, use_dask=False, 
+    def _read_filenames(cls, filenames, use_dask=False,
                            as_path=False, persist=False,
                            **kwargs):
         """ """
         filenames = np.atleast_1d(filenames).tolist()
-        
+
         prop = {**dict(as_path=as_path, use_dask=use_dask), **kwargs}
 
         # Collection of what ?
@@ -759,24 +759,24 @@ class _Collection_( object ):
             COLLECTION_OF = cls._COLLECTION_OF
         else:
             COLLECTION_OF = cls._guess_filenames_imgtype_(filenames)
-        
+
         # dask is called inside this.
         images = [COLLECTION_OF.from_filename(filename, **prop) for filename in filenames]
         if use_dask and persist:
             images = [i.persist() for i in images]
-            
+
         return images, filenames
 
     @staticmethod
     def _guess_filenames_imgtype_(filenames):
         """ guess the Image Class given the filenames
-        
+
         Only sci->ScienceQuadrant and raw->RawCCD implemented.
 
-        This will raise a NotImplementedError if multiple kinds of filenames 
+        This will raise a NotImplementedError if multiple kinds of filenames
         are given.
-        
-        
+
+
         """
         from ztfquery import io
         kind = io.filename_to_kind(filenames)
@@ -784,7 +784,7 @@ class _Collection_( object ):
             raise NotImplementedError("Only single filename image kind inplemented.")
         else:
             kind = kind[0] # sci, raw or cal
-            
+
         # Works
         if kind == "sci":
             from .science import ScienceQuadrant
@@ -794,9 +794,9 @@ class _Collection_( object ):
             imgtype = RawCCD
         else:
             raise NotImplementedError(f"Only sci and raw image kind implemented ; {kind} given")
-        
+
         return imgtype
-            
+
     def _get_subdata(self, calling="get_data", **kwargs):
         """ get a stack of the data from get_data collection of """
         datas = self._call_down(calling, **kwargs)
@@ -812,7 +812,7 @@ class _Collection_( object ):
         else:
             # numpy.array stack
             datas = np.stack(datas)
-            
+
         return datas
 
     # -------- #
@@ -822,47 +822,47 @@ class _Collection_( object ):
         """ """
         return [getattr(img, what)(marg, *args, **kwargs)
                 for img, marg in zip(self._images, margs)]
-    
+
     def _call_down(self, what, *args, **kwargs):
         """ call an attribute or a method to each image.
-        
+
         Parameters
         ----------
         what: str
             attribute or method of individual images.
-            
-        args, kwargs: 
-            = ignored if what is an attribute = 
+
+        args, kwargs:
+            = ignored if what is an attribute =
             method options
-            
+
         See also
         --------
         _map_down: map a list to the list of image
         """
         import inspect
-        
+
         if inspect.ismethod( getattr(self._images[0], what) ): # is func ?
             return [getattr(img, what)(*args, **kwargs) for img in self._images]
-        
+
         return [getattr(img, what) for img in self._images]
 
 
     def compute(self, **kwargs):
         """ compute all dasked images
         = careful this may load a lot of data in memory =
-        
+
         Ignored if not use_dask.
-            
+
         **kwargs goes to individual's image compte().
         """
         warnings.warn("compute of a collection is not optimal yet. Loops over images to call their compute.")
         _ = self._call_down("compute", **kwargs)
         self._use_dask = False # if needed be
-        
+
     def persist(self, **kwargs):
         """ persist all dasked images
         = this loads data in your cluster's memory =
-        
+
         **kwargs goes to individual's image compte().
         """
         _ = self._call_down("persist", **kwargs)
@@ -875,7 +875,7 @@ class _Collection_( object ):
         """ name of the collection elements. """
         if not hasattr(self, "_collection_of") or self._collection_of is None:
             self._collection_of = self._COLLECTION_OF
-            
+
         return self._collection_of
 # -------------- #
 #                #
@@ -895,18 +895,18 @@ class Quadrant(Image):
     #  GETTER  #
     # -------- #
     def get_ccd(self, use_dask=None, as_path=False, **kwargs):
-        """ get the ccd object containing this quadrant. 
+        """ get the ccd object containing this quadrant.
         (see self._CCDCLASS)
 
         Parameters
         ----------
         use_dask: bool, None
-            should the ccd object be build using dask ? 
+            should the ccd object be build using dask ?
             if None, the current instance use_dask is used.
-        
+
         as_path: bool
-            should this assume that instance self.filename can 
-            be directly transformed ? False should be favored 
+            should this assume that instance self.filename can
+            be directly transformed ? False should be favored
             as it downloads the missing images if need.
 
         **kwargs goes the self._CCDCLASS.from_single_filename()
@@ -918,14 +918,14 @@ class Quadrant(Image):
         """
         if use_dask is None:
             use_dask = self.use_dask
-        
+
         return self._ccdclass.from_single_filename(self.filename,
                                                    use_dask=use_dask,
                                                    as_path=as_path,
                                                    **kwargs)
 
     def get_focalplane(self, use_dask=None, as_path=False, **kwargs):
-        """ get the full focal plane (64 quadrants making 16 CCDs) 
+        """ get the full focal plane (64 quadrants making 16 CCDs)
         containing this quadrant
 
         (see self._FocalPlaneCLASS)
@@ -933,12 +933,12 @@ class Quadrant(Image):
         Parameters
         ----------
         use_dask: bool, None
-            should the ccd object be build using dask ? 
+            should the ccd object be build using dask ?
             if None, the current instance use_dask is used.
-        
+
         as_path: bool
-            should this assume that instance self.filename can 
-            be directly transformed ? False should be favored 
+            should this assume that instance self.filename can
+            be directly transformed ? False should be favored
             as it downloads the missing images if need.
 
         **kwargs goes the self._FocalPlaneCLASS.from_single_filename()
@@ -950,15 +950,15 @@ class Quadrant(Image):
         """
         if use_dask is None:
             use_dask = self.use_dask
-        
+
         return self._focalplaneclass.from_single_filename(self.filename,
                                                           use_dask=use_dask,
                                                           as_path=as_path,
                                                           **kwargs)
-    
+
     def get_data(self, rebin=None, reorder=True, **kwargs):
-        """ get image data 
-        
+        """ get image data
+
         Parameters
         ----------
         rebin: int, None
@@ -972,7 +972,7 @@ class Quadrant(Image):
         reorder: bool
             Should the data be re-order to match the actual north-up.
             (leave to True if not sure)
-            
+
         **kwargs goes to super.get_data() e.g. rebin_stat
 
         Returns
@@ -983,20 +983,20 @@ class Quadrant(Image):
         data = super().get_data(rebin=rebin, **kwargs)
         if reorder:
             data = self._reorder_data(data)
-            
+
         return data
 
     @staticmethod
     def _reorder_data(data):
         """ internal tool to reorder data """
         return data[::-1,::-1]
-        
 
-    def get_catalog(self, name, fieldcat=False, radius=0.7, 
+
+    def get_catalog(self, name, fieldcat=False, radius=0.7,
                         reorder=True, in_fov=False,
                         use_dask=None, **kwargs):
         """ get a catalog for the image
-        
+
         Parameters
         ----------
         name: str
@@ -1005,22 +1005,22 @@ class Quadrant(Image):
 
         fieldcat: bool
             is the catalog you are looking for a "field catalog" ?
-            (see catalog.py). See list of available names in 
+            (see catalog.py). See list of available names in
             name parameter doc.
 
         radius: float
             = ignored if fieldcat is True =
-            radius [in degree] of the cone search 
-            centered on the quadrant position. 
+            radius [in degree] of the cone search
+            centered on the quadrant position.
             radius=0.7 is slightly larger that half a diagonal.
 
         reorder: bool
-            when creating the x and y columns given the 
+            when creating the x and y columns given the
             catalog ra, dec, should this assume x and y reordered
-            position. 
-            reorder=True matches data from get_data() but not self.data. 
+            position.
+            reorder=True matches data from get_data() but not self.data.
             (leave to True if unsure).
-        
+
         in_fov: bool
             should entries outside the image footprint be droped ?
             (ignored if x and y column setting fails).
@@ -1028,24 +1028,24 @@ class Quadrant(Image):
         use_dask: bool
             should this return a dask.dataframe for the catalog ?
             If None, this will use self.use_dask.
-            
+
         **kwargs goes to get_field_catalog or download_vizier_catalog.
-        
+
         Returns
         -------
         DataFrame
             catalog dataframe. The image x, y coordinates columns will be added
             using the radec_to_xy method. If not available, NaN will be set.
-            
+
         """
         if use_dask is None:
             use_dask = self.use_dask
-        
+
         if fieldcat:
             from .catalog import get_field_catalog
             cat = get_field_catalog(name,
                                     fieldid=self.get_value("fieldid"),
-                                    rcid=self.get_value("rcid", None), 
+                                    rcid=self.get_value("rcid", None),
                                     ccdid=self.get_value("ccdid", None), # ignored if rcid is not None
                                     use_dask=use_dask,
                                     **kwargs)
@@ -1062,7 +1062,7 @@ class Quadrant(Image):
 
     def add_coord_to_catalog(self, cat, coord='ij', ra="ra", dec="dec", reorder=True, in_fov=False):
         """ add the quadrant xy coordinates to a given catalog if possible.
-        
+
         This assume that radec_to_xy is implemented for this instance.
 
         Parameters
@@ -1078,12 +1078,12 @@ class Quadrant(Image):
 
         coord: str
             Coord to add to given catalogue. 'ij' or 'xy'
-            
+
         reorder: bool
-            when creating the x and y columns given the 
+            when creating the x and y columns given the
             catalog ra, dec, should this assume x and y reordered
-            position. 
-            reorder=True matches data from get_data() but not self.data. 
+            position.
+            reorder=True matches data from get_data() but not self.data.
             (leave to True if unsure).
 
         in_fov: bool
@@ -1093,7 +1093,7 @@ class Quadrant(Image):
         Returns
         -------
         DataFrame
-            pandas or dask. 
+            pandas or dask.
 
         See also
         --------
@@ -1101,7 +1101,7 @@ class Quadrant(Image):
         """
         # is catalog dasked ?
         dasked_cat = "dask" in str( type(cat) )
-        
+
         # Adding x, y coordinates
         # convertion available ?
         if hasattr(self, f"radec_to_{coord}") and ra in cat and dec in cat:
@@ -1118,18 +1118,18 @@ class Quadrant(Image):
                 x, y = da.NaN, da.NaN
             else:
                 x, y = np.nan, np.nan
-                
+
             in_fov = False
-            
+
         cat[coord[0]] = x
         cat[coord[1]] = y
         if in_fov:
             cat = cat[cat[coord[0]].between(0, self.shape[-1]) &
                       cat[coord[1]].between(0, self.shape[0]) ]
-            
+
         return cat
-        
-        
+
+
     def get_center(self, system="xy", reorder=True):
         """ get the center of the image
 
@@ -1145,7 +1145,7 @@ class Quadrant(Image):
         reorder: bool
             should this provide the coordinates assuming
             normal ordering (+ra right, +dec up) (True) ?
-            = leave True if unsure = 
+            = leave True if unsure =
 
         Returns
         -------
@@ -1158,14 +1158,14 @@ class Quadrant(Image):
 
         if system in ["ccd", "ij"]:
             return np.squeeze(self.xy_to_ij(*center_pixel) )
-        
+
         if system in ["uv","tangent"]:
             return np.squeeze(self.xy_to_uv(*center_pixel, reorder=reorder) )
-        
+
         if system in ["radec","coords","worlds"]:
             return np.squeeze(self.xy_to_radec(*center_pixel, reorder=reorder) )
 
-        raise ValueError(f"{system} system not recognized. 'xy', 'ij', 'radec' or 'uv'")            
+        raise ValueError(f"{system} system not recognized. 'xy', 'ij', 'radec' or 'uv'")
 
     def get_corners(self, system="xy", reorder=True):
         """ get the corners of the image.
@@ -1180,31 +1180,31 @@ class Quadrant(Image):
             - uv: camera coordinates (in arcsec)
 
         reorder: bool
-            = ignored if system='xy' =    
+            = ignored if system='xy' =
             should this provide the coordinates assuming
             normal ordering (+ra right, +dec up) (True) ?
-            Leave default if unsure. 
+            Leave default if unsure.
 
         Returns
         -------
         2d-array
             lower-left, lower-right, upper-right, upper-left
         """
-        # 
-        corners = np.stack([[0,0], 
+        #
+        corners = np.stack([[0,0],
                             [self.shape[1],0],
                             [self.shape[1],self.shape[0]],
                             [0,self.shape[0]]])
 
         if system in ['xy', "pixels"]:
             return corners
-        
+
         if system in ["ccd", "ij"]:
             return self.xy_to_ij(*corners.T).T
-        
+
         if system == "radec":
             return self.xy_to_radec(*corners.T, reorder=True).T
-        
+
         if system == "uv":
             return self.xy_to_uv(*corners.T, reorder=True).T
 
@@ -1233,7 +1233,7 @@ class Quadrant(Image):
         --------
         persist: persists (some) delayed attributes
         """
-        
+
         if not self.use_dask:
             warnings.warn("dask not used ; nothing to do.")
             return
@@ -1257,7 +1257,7 @@ class Quadrant(Image):
             If None, all dasked attributes will be used.
 
         **kwargs goes to delayed.persist(**kwargs)
-        
+
         Return
         ------
         None
@@ -1266,7 +1266,7 @@ class Quadrant(Image):
         --------
         compute: computes delayed attributes
         """
-        
+
         if not self.use_dask:
             warnings.warn("dask not used ; nothing to do.")
             return
@@ -1287,15 +1287,15 @@ class Quadrant(Image):
         to_be_check = ["_data", "_mask", "_filepath", "_header"]
         return [attr for attr in to_be_check
                     if hasattr(self, attr) and  "dask" in str( type( getattr(self, attr) ) )]
-        
+
     # =============== #
     #  Properties     #
-    # =============== #    
+    # =============== #
     @property
     def qid(self):
         """ quadrant id (from header) """
         return self.get_value("QID", None, attr_ok=False) # avoid loop
-        
+
     @property
     def ccdid(self):
         """ ccd id (from header) """
@@ -1313,10 +1313,10 @@ class Quadrant(Image):
         if type(cls._CCDCLASS) is str:
             try: # from this .py
                 return eval( cls._CCDCLASS )
-            except: # from the library 
+            except: # from the library
                 exec(f"from .__init__ import {cls._CCDCLASS}")
                 return eval( cls._CCDCLASS )
-        
+
         return cls._CCDCLASS
 
     @classproperty
@@ -1325,13 +1325,13 @@ class Quadrant(Image):
         if type(cls._FocalPlaneCLASS) is str:
             try: # from this .py
                 return eval( cls._FocalPlaneCLASS )
-            except: # from the library 
+            except: # from the library
                 exec(f"from .__init__ import {cls._FocalPlaneCLASS}")
                 return eval( cls._FocalPlaneCLASS )
 
-        
+
         return cls._FocalPlaneCLASS
-    
+
 # -------------- #
 #                #
 #     CCD        #
@@ -1351,41 +1351,41 @@ class CCD( Image, _Collection_):
                      data=None, header=None,
                      pos_inverted=None, **kwargs):
         """ CCD are collections for quadrants except if loaded from whole CCD data.
-        
+
 
         See also
         --------
-        from_filename: load the instance given a filename 
+        from_filename: load the instance given a filename
         from_filenames: load the image given the list of its four quadrant filenames
         from_single_filename: build and load the instance given the filename of a single quadrant.
         """
         if data is not None and quadrants is not None:
             raise ValueError("both quadrants and data given. This is confusing. Use only one.")
-        
+
         # - Ok good to go
         _ = super().__init__()
 
         if data is not None:
             # this updates use_dask
             self.set_data(data)
-            
+
         if header is not None:
             self.set_header(header)
-        
+
         if quadrants is not None:
             if qids is None:
                 qids = [None]*len(quadrants)
-                
+
             elif len(quadrants) != len(qids):
                 raise ValueError("quadrants and qids must have the same size.")
-            
+
             # this updates use_dask
             _ = [self.set_quadrant(quad_, qid=qid, **kwargs)
                      for quad_, qid in zip(quadrants, qids)]
-                
+
     # =============== #
     #  I/O            #
-    # =============== #        
+    # =============== #
     @classmethod
     def from_single_filename(cls, filename, as_path=True, use_dask=False, persist=False, **kwargs):
         """ given a single quadrant file, this fetchs the missing ones and loads the instance.
@@ -1395,13 +1395,13 @@ class CCD( Image, _Collection_):
         filename: str
             filename of a single *quadrant* filename.
             This will look for the 3 missing to build the ccd.
-            
+
         as_path: bool -optional-
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
-        
+
         use_dask: bool, optional
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool, optional
@@ -1437,11 +1437,11 @@ class CCD( Image, _Collection_):
         Parameters
         ----------
         quadrants: list of ztfimg.Quadrants
-            the for quadrants 
+            the for quadrants
 
         qids: None, list of int
             the quadrants idea (otherise taken from the quadrants)
-            
+
         Returns
         -------
         class instance
@@ -1466,8 +1466,8 @@ class CCD( Image, _Collection_):
         Parameters
         ----------
         filanames: list of four str
-            filenames for the four quadrants 
-        
+            filenames for the four quadrants
+
         as_path: bool
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
@@ -1476,9 +1476,9 @@ class CCD( Image, _Collection_):
             list of the qid for the input filenames
 
         use_dask: bool
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
- 
+
         persist: bool
             = only applied if use_dask=True =
             should we use dask's persist() on data ?
@@ -1503,11 +1503,11 @@ class CCD( Image, _Collection_):
         ----------
         fileout: str
             path to where the data should be stored. (fits file)
-            
+
         as_quadrant: bool
-            should the data stored as 4 quadrant hdu images (True) 
+            should the data stored as 4 quadrant hdu images (True)
             or one larger image (as_quadrant=False)
-            
+
         overwrite: bool
             if fileout already exists, shall this overwrite it ?
 
@@ -1524,19 +1524,19 @@ class CCD( Image, _Collection_):
         if not as_quadrants:
             out = self._to_fits(fileout, data=self.data, header=self.header,
                               overwrite=overwrite, **kwargs)
-            
+
         else:
             quadrant_datas = self.get_quadrantdata()
             primary_hdu = [fits.PrimaryHDU(data=None, header=self.header)]
             quadrant_hdu = [fits.ImageHDU(qdata_) for qdata_ in quadrant_datas]
             hdulist = fits.HDUList(primary_hdu +quadrant_hdu) # list + list
             out = hdulist.writeto(fileout, overwrite=overwrite, **kwargs)
-            
+
         return out
 
     def to_quadrant_fits(self, quadrantfiles, overwrite=True, from_data=True,
                     **kwargs):
-        """ dump the current image into 4 different files: one for each quadrants 
+        """ dump the current image into 4 different files: one for each quadrants
 
         Parameters
         ----------
@@ -1547,11 +1547,11 @@ class CCD( Image, _Collection_):
             if fileout already exists, shall this overwrite it ?
 
         from_data: bool
-            option of get_quadrantdata(). If both self.data exists and self.qudrants, 
-            should the data be taken from self.data (from_data=True) or from the 
-            individual quadrants (from_data=False) using 
+            option of get_quadrantdata(). If both self.data exists and self.qudrants,
+            should the data be taken from self.data (from_data=True) or from the
+            individual quadrants (from_data=False) using
             ``self.quadrants[i].get_data()``
-        
+
         Returns
         -------
         None
@@ -1571,7 +1571,7 @@ class CCD( Image, _Collection_):
 
     @classmethod
     def _to_quadrant_fits(cls, fileouts, datas, header, overwrite=True, **kwargs):
-        """ dump the current image into 4 different files: one for each quadrants 
+        """ dump the current image into 4 different files: one for each quadrants
 
         = Internal method =
 
@@ -1591,11 +1591,11 @@ class CCD( Image, _Collection_):
             if fileout already exists, shall this overwrite it ?
 
         from_data: bool
-            option of get_quadrantdata(). If both self.data exists and self.qudrants, 
-            should the data be taken from self.data (from_data=True) or from the 
-            individual quadrants (from_data=False) using 
+            option of get_quadrantdata(). If both self.data exists and self.qudrants,
+            should the data be taken from self.data (from_data=True) or from the
+            individual quadrants (from_data=False) using
             ``self.quadrants[i].get_data()``
-        
+
         Returns
         -------
         None
@@ -1609,7 +1609,7 @@ class CCD( Image, _Collection_):
         for file_, data_, header_ in zip(fileouts, datas, header):
             cls._quadrantclass._to_fits(file_, data=data_, header=header_,
                                             overwrite=overwrite, **kwargs)
-    
+
     # --------- #
     #  LOADER   #
     # --------- #
@@ -1623,7 +1623,7 @@ class CCD( Image, _Collection_):
     # --------- #
     def set_quadrant(self, quadrant, qid=None):
         """ set the quadrants to the instance.
-        
+
         = It is unlikely you need to use that directly. =
 
         Parameters
@@ -1633,7 +1633,7 @@ class CCD( Image, _Collection_):
             will be added to ``self.quadrants[qid]``
 
         qid: int, None
-            quadrant id. If not provided, it will be taken from 
+            quadrant id. If not provided, it will be taken from
             quadrant.qid.
 
         Returns
@@ -1644,14 +1644,14 @@ class CCD( Image, _Collection_):
         --------
         from_filenames: load the image given the list of its four quadrant filenames
         from_single_filename: build and load the instance given the filename of a single quadrant.
- 
+
         """
         self._meta = None
         # dasked quadrants
         if "dask" in str( type(quadrant) ):
             self._use_dask = True
             self.quadrants[qid] = quadrant
-            
+
         # quadrants
         else:
             if qid is None:
@@ -1664,12 +1664,12 @@ class CCD( Image, _Collection_):
     #  Call     #
     # --------- #
     def call_quadrants(self, what, *args, **kwargs):
-        """ run the given input on quadrants 
+        """ run the given input on quadrants
 
         Parameters
         ----------
         what: str
-            method or attribute of quadrants or anything 
+            method or attribute of quadrants or anything
             accessing through quadrant.get_value()
 
         *args goes to each quadrant.what() if method
@@ -1684,9 +1684,9 @@ class CCD( Image, _Collection_):
         if not hasattr(q0, what):
             kwargs["key"] = what
             what = "get_value"
-        
+
         return self._call_down(what, *args, **kwargs)
-    
+
     # --------- #
     #  GETTER   #
     # --------- #
@@ -1695,7 +1695,7 @@ class CCD( Image, _Collection_):
         return self.quadrants[qid]
 
     def get_focalplane(self, use_dask=None, **kwargs):
-        """ get the full focal plane (64 quadrants making 16 CCDs) 
+        """ get the full focal plane (64 quadrants making 16 CCDs)
         containing this quadrant
 
         (see self._FocalPlaneCLASS)
@@ -1703,12 +1703,12 @@ class CCD( Image, _Collection_):
         Parameters
         ----------
         use_dask: bool, None
-            should the ccd object be build using dask ? 
+            should the ccd object be build using dask ?
             if None, the current instance use_dask is used.
-        
+
         as_path: bool
-            should this assume that instance self.filename can 
-            be directly transformed ? False should be favored 
+            should this assume that instance self.filename can
+            be directly transformed ? False should be favored
             as it downloads the missing images if need.
 
         **kwargs goes the self._FocalPlaneCLASS.from_single_filename()
@@ -1720,19 +1720,19 @@ class CCD( Image, _Collection_):
         """
         if use_dask is None:
             use_dask = self.use_dask
-            
+
         if self.filename is None:
             filename = self.filenames[0]
         else:
             filename = self.filename
-            
+
         return self._focalplaneclass.from_single_filename(filename,
                                                           use_dask=use_dask,
                                                           **kwargs)
-    
+
     def get_quadrantheader(self):
-        """ get a DataFrame gathering the quadrants's header 
-        
+        """ get a DataFrame gathering the quadrants's header
+
         Returns
         -------
         DataFrame
@@ -1740,7 +1740,7 @@ class CCD( Image, _Collection_):
         """
         if not self.has_quadrants():
             return None
-        
+
         qid_range = [1, 2, 3, 4]
         hs = [quadrant.get_header() for i in qid_range
                   if (quadrant:=self.get_quadrant(i)) is not None]
@@ -1751,15 +1751,15 @@ class CCD( Image, _Collection_):
     def get_quadrantdata(self, from_data=False, rebin=None, rebin_stat="mean",
                              reorder=True, **kwargs):
         """ get the quadrant's data.
-        
+
         Parameters
         ----------
         from_data: bool
-            if self.data exists, should the quadrant be taken from it 
+            if self.data exists, should the quadrant be taken from it
             (spliting it into 4 quadrants) ?
             if not, it will be taken from self.get_quadrant(i).get_data()
-        
-        
+
+
         rebin: int, None
             Shall the data be rebinned by square of size `rebin` ?
             None means no rebinning.
@@ -1797,24 +1797,24 @@ class CCD( Image, _Collection_):
 
         if self.has_quadrants() and not from_data:
             qdata = self._get_subdata(rebin=rebin, reorder=reorder, **kwargs) # internal method of _Collection_
-            
+
         else:
             q4 = self.data[:self.qshape[0],self.qshape[1]:]
             q1 = self.data[self.qshape[0]:,self.qshape[1]:]
-            q3 = self.data[:self.qshape[0],:self.qshape[1]] 
+            q3 = self.data[:self.qshape[0],:self.qshape[1]]
             q2 = self.data[self.qshape[0]:,:self.qshape[1]]
-            
+
             qdata = [q1,q2,q3,q4]
             if not reorder: # self.data is expected to be reodered
                 qdata = [q[::-1,::-1] for q in qdata]
-            
+
             if rebin is not None:
                 npda = da if self.use_dask else np
                 qdata = getattr(npda, rebin_stat)(rebin_arr(qdata, (rebin, rebin),
                                                         use_dask=self.use_dask),
                                               axis=(-2, -1))
         return qdata
-        
+
     def get_data(self, rebin=None, rebin_quadrant=None,
                      rebin_stat="mean",
                      rebuild=False, persist=False,
@@ -1830,7 +1830,7 @@ class CCD( Image, _Collection_):
             rebin must be a multiple of the image shape.
             for instance if the input shape is (6160, 6144)
             rebin could be 2,4,8 or 16
-            = rebin is applied to the whole ccd image see 
+            = rebin is applied to the whole ccd image see
             rebin_quadrant for rebinning at the quadrant level =
 
         rebin_quadrant: int, None
@@ -1845,8 +1845,8 @@ class CCD( Image, _Collection_):
             The dimension of the final image will depend on rebin.
 
         rebuild: bool
-            if self.data exist and rebin_quadrant is None, then 
-            ``self.data.copy()`` will be used. If rebuild=True, 
+            if self.data exist and rebin_quadrant is None, then
+            ``self.data.copy()`` will be used. If rebuild=True,
             then this will be re-build the data and ignore self.data
 
         persist: bool
@@ -1857,27 +1857,27 @@ class CCD( Image, _Collection_):
         -------
         2d-array
             dask or numpy array
-        
+
         See also
         --------
         get_quadrantdata: get a list of all the individual quadrant data.
-    
+
         Examples
         --------
         get the ccd image and rebin it by 4
         >>> ccdimg.get_data(rebin=4).shape
-        
-        
+
+
         """
         # the normal case
         if self.has_data() and not rebuild and rebin_quadrant is None:
             data_ = self.data.copy()
         else:
             data_ = self._quadrantdata_to_ccddata(rebin_quadrant=rebin_quadrant, **kwargs)
-           
+
         if self.use_dask and persist:
             data_ = data_.persist()
-            
+
         return data_
 
 
@@ -1886,7 +1886,7 @@ class CCD( Image, _Collection_):
         """ get a catalog for the image.
 
         This method calls down to the individual quadrant's get_catalog
-        and merge them while updating their x,y position to make x,y 
+        and merge them while updating their x,y position to make x,y
         ccd pixels and not quadrant pixels.
 
         """
@@ -1894,7 +1894,7 @@ class CCD( Image, _Collection_):
                                 name, fieldcat=fieldcat,
                                 in_fov=in_fov, use_dask=use_dask,
                                 **kwargs)
-        
+
         # updates the quadrants. recall:
         # q2 | q1
         # --------
@@ -1905,7 +1905,7 @@ class CCD( Image, _Collection_):
         cats[1]["y"] += self.qshape[0]
         # -> merging
         cat = pandas.concat(cats)
-        
+
         if drop_duplicate:
             if sourcekey not in cat:
                 warnings.warn(f"cannot drop duplicated based on {sourcekey}: not in catalog")
@@ -1925,14 +1925,14 @@ class CCD( Image, _Collection_):
         system: string
             coordinate system.
             # for ccds xy and ij are the same
-            - xy / ij: image pixel coordinates 
+            - xy / ij: image pixel coordinates
             - radec: sky coordinates (in deg)
             - uv: camera coordinates (in arcsec)
 
         reorder: bool
             should this provide the coordinates assuming
             normal ordering (+ra right, +dec up) (True) ?
-            = leave True if unsure = 
+            = leave True if unsure =
 
         Returns
         -------
@@ -1945,13 +1945,13 @@ class CCD( Image, _Collection_):
         # q3 | q4s
         if system in ["xy", "ij"]:
             return self.qshape
-        
+
         if system == "radec":
             return self.get_quadrant(1).xy_to_radec(0,0).squeeze()
-        
+
         if system == "uv":
             return self.get_quadrant(1).xy_to_uv(0,0).squeeze()
-        
+
         raise ValueError(f"{system} system not recognized. 'xy', 'radec' or 'uv'")
 
     def get_corners(self, system="xy", reorder=True):
@@ -1967,35 +1967,35 @@ class CCD( Image, _Collection_):
             - uv: camera coordinates (in arcsec)
 
         reorder: bool
-            = ignored if system='xy' =    
+            = ignored if system='xy' =
             should this provide the coordinates assuming
             normal ordering (+ra right, +dec up) (True) ?
-            Leave default if unsure. 
+            Leave default if unsure.
 
         Returns
         -------
         2d-array
             lower-left, lower-right, upper-right, upper-left
         """
-        # 
-        corners = np.stack([[0,0], 
+        #
+        corners = np.stack([[0,0],
                             [self.shape[1],0],
                             [self.shape[1],self.shape[0]],
                             [0,self.shape[0]]])
-    
+
         if system in ['xy', "ij"]:
             return corners
-                
+
         if system == "radec":
             return self.get_quadrant(1).ij_to_radec(*corners.T, reorder=True).T
-        
+
         if system == "uv":
             return self.get_quadrant(1).ij_to_uv(*corners.T, reorder=True).T
 
         raise ValueError(f"{system} system not recognized. 'xy', 'ij', 'radec' or 'uv'")
 
 
-    
+
     # - internal get
     def _quadrantdata_to_ccddata(self, rebin_quadrant=None, qdata=None, **kwargs):
         """ combine the ccd data into the quadrants"""
@@ -2003,7 +2003,7 @@ class CCD( Image, _Collection_):
         npda = da if self.use_dask else np
         if qdata is None:
             qdata = self.get_quadrantdata(rebin=rebin_quadrant, **kwargs)
-        
+
         # ccd structure
         # q2 | q1
         # q3 | q4
@@ -2014,7 +2014,7 @@ class CCD( Image, _Collection_):
 
     def add_coord_to_catalog(self, cat, coord='ij', ra="ra", dec="dec", reorder=True, in_fov=False):
         """ add the quadrant xy coordinates to a given catalog if possible.
-        
+
         This assume that radec_to_xy is implemented for this instance.
 
         Parameters
@@ -2030,12 +2030,12 @@ class CCD( Image, _Collection_):
 
         coord: str
             Coord to add to given catalogue. 'ij' or 'xy'
-            
+
         reorder: bool
-            when creating the x and y columns given the 
+            when creating the x and y columns given the
             catalog ra, dec, should this assume x and y reordered
-            position. 
-            reorder=True matches data from get_data() but not self.data. 
+            position.
+            reorder=True matches data from get_data() but not self.data.
             (leave to True if unsure).
 
         in_fov: bool
@@ -2045,7 +2045,7 @@ class CCD( Image, _Collection_):
         Returns
         -------
         DataFrame
-            pandas or dask. 
+            pandas or dask.
 
         See also
         --------
@@ -2053,7 +2053,7 @@ class CCD( Image, _Collection_):
         """
         # is catalog dasked ?
         dasked_cat = "dask" in str( type(cat) )
-        
+
         # Adding x, y coordinates
         # convertion available ?
         if hasattr(self, f"radec_to_{coord}") and ra in cat and dec in cat:
@@ -2070,21 +2070,21 @@ class CCD( Image, _Collection_):
                 x, y = da.NaN, da.NaN
             else:
                 x, y = np.nan, np.nan
-                
+
             in_fov = False
-            
+
         cat[coord[0]] = x
         cat[coord[1]] = y
         if in_fov:
             cat = cat[cat[coord[0]].between(0, self.shape[-1]) &
                       cat[coord[1]].between(0, self.shape[0]) ]
-            
+
         return cat
-        
-    def show_footprint(self, values="qid", ax=None, 
+
+    def show_footprint(self, values="qid", ax=None,
                         system="ij", cmap="coolwarm",
-                        vmin=None, vmax=None, 
-                        quadrant_id="qid", #in_deg=True, 
+                        vmin=None, vmax=None,
+                        quadrant_id="qid", #in_deg=True,
                         **kwargs):
         """ illustrate the image footprint
 
@@ -2092,7 +2092,7 @@ class CCD( Image, _Collection_):
         ----------
         values: str, None, array, dict, pandas.Series
             values to be displaid as facecolor in the image.
-            - str: understood as a quadrant properties 
+            - str: understood as a quadrant properties
                    (using call_quadrants)
             - None: (or 'None') no facecolor (just edge)
             - array: value to be displaid. size of 4.
@@ -2103,19 +2103,19 @@ class CCD( Image, _Collection_):
             axes where to draw the plot
 
         system: str
-            coordinates system: 
-            - xy: quadrant 
+            coordinates system:
+            - xy: quadrant
             - ij: ccd (favored)
             - uv: focalplane
 
         cmap: str or matplotlib's cmap
-            colormap 
+            colormap
 
-        vmin, vmax: 
+        vmin, vmax:
             boundaries for the colormap
 
         quadrant_id: str or None
-            value indicated in the quadrants. 
+            value indicated in the quadrants.
             None means no text written.
 
         **kwargs goes to matplotlib.patches.Polygon
@@ -2135,7 +2135,7 @@ class CCD( Image, _Collection_):
             ax = fig.add_axes([0.15,0.15,0.8,0.8])
         else:
             fig = ax.figure
-            
+
         prop = dict(lw=0, alpha=0.8, zorder=3)
 
         # ---------
@@ -2151,20 +2151,20 @@ class CCD( Image, _Collection_):
             if values == "None": # like in matplotlib
                 values = None
             else:
-                values = self.call_quadrants(values) 
+                values = self.call_quadrants(values)
         elif values is not None:
             # reindex
             values = pandas.Series(values).reindex( np.arange(4) ).values
-        
+
         if values is not None:
-            if vmin is None: 
+            if vmin is None:
                 vmin = np.nanmin(values)
-            if vmax is None: 
+            if vmax is None:
                 vmax = np.nanmax(values)
             norm = Normalize(vmin=vmin, vmax=vmax)
 
 
-        # using center and corner as debug, center could be derived from corners. 
+        # using center and corner as debug, center could be derived from corners.
         centers = np.stack(self.call_quadrants("get_center", system=system))
         corners = np.stack(self.call_quadrants("get_corners", system=system))
 
@@ -2217,7 +2217,7 @@ class CCD( Image, _Collection_):
             #self.load_data()
 
         return self._data
-        
+
     @property
     def quadrants(self):
         """ dictionnary of the quadrants, keys are the quadrant id"""
@@ -2229,7 +2229,7 @@ class CCD( Image, _Collection_):
     def _images(self):
         """ Internal property for _Collection_ methods """
         return list( self.quadrants.values() )
-    
+
     def has_quadrants(self, logic="all"):
         """ are (all/any, see option) quadrant loaded ? """
         is_none = [v is not None for v in self.quadrants.values()]
@@ -2255,15 +2255,15 @@ class CCD( Image, _Collection_):
         """ list of the filepath of the different quadrants constituing the data. """
         return [q.filepath for qid, q in self.quadrants.items()]
 
-    
+
     # family
     @classproperty
     def _quadrantclass(cls):
         """ """
-        if type( cls._QUADRANTCLASS ) is str:            
+        if type( cls._QUADRANTCLASS ) is str:
             try: # from this .py
                 return eval( cls._QUADRANTCLASS )
-            except: # from the library 
+            except: # from the library
                 exec(f"from .__init__ import {cls._QUADRANTCLASS}")
                 return eval( cls._QUADRANTCLASS )
 
@@ -2275,41 +2275,41 @@ class CCD( Image, _Collection_):
         if type(cls._FocalPlaneCLASS) is str:
             try: # from this .py
                 return eval( cls._FocalPlaneCLASS )
-            except: # from the library 
+            except: # from the library
                 exec(f"from .__init__ import {cls._FocalPlaneCLASS}")
                 return eval( cls._FocalPlaneCLASS )
 
-        
+
         return cls._FocalPlaneCLASS
-    
+
 # -------------- #
 #                #
 #  Focal Plane   #
 #                #
 # -------------- #
 class FocalPlane(Image, _Collection_):
-    
+
     _COLLECTION_OF = CCD
     # Family
     _CCDCLASS = "CCD"
-    
+
     # Basically a CCD collection
     def __init__(self, ccds=None, ccdids=None,
                      data=None, header=None, **kwargs):
-        """ 
+        """
 
         See also
         --------
-        from_filename: load the instance given a filename 
+        from_filename: load the instance given a filename
         from_filenames: load the image given the list of its quadrant filenames
         from_single_filename: build and load the instance given the filename of a single quadrant.
         """
         _ = super().__init__(data=data, header=header)
-        
+
         if ccds is not None:
             if ccdids is None:
                 ccdids = [None]*len(ccds)
-                
+
             elif len(ccds) != len(ccdids):
                 raise ValueError("ccds and ccdids must have the same size.")
 
@@ -2328,8 +2328,8 @@ class FocalPlane(Image, _Collection_):
         Parameters
         ----------
         filanames: list of four str
-            filenames for the four quadrants 
-        
+            filenames for the four quadrants
+
         as_path: bool
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
@@ -2338,9 +2338,9 @@ class FocalPlane(Image, _Collection_):
             list of the rcid (0->63) for the input filenames
 
         use_dask: bool
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
- 
+
         persist: bool
             = only applied if use_dask=True =
             should we use dask's persist() on data ?
@@ -2368,7 +2368,7 @@ class FocalPlane(Image, _Collection_):
         ccds = [cls._ccdclass.from_filenames(qfiles, qids=[1, 2, 3, 4], as_path=as_path,
                                                  use_dask=use_dask, persist=persist, **kwargs)
                 for qfiles in ccdidlist.values]
-            
+
         return cls(ccds, np.asarray(ccdidlist.index, dtype="int"),
                    use_dask=use_dask)
 
@@ -2382,13 +2382,13 @@ class FocalPlane(Image, _Collection_):
         filename: str
             filename of a single *quadrant* filename.
             This will look for the 3 missing to build the ccd.
-            
+
         as_path: bool -optional-
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
-        
+
         use_dask: bool, optional
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool, optional
@@ -2417,17 +2417,17 @@ class FocalPlane(Image, _Collection_):
     #   Methods       #
     # =============== #
     def set_ccd(self, ccd, ccdid=None):
-        """ attach ccd images to the instance. 
+        """ attach ccd images to the instance.
 
         Parameters
         ----------
         ccd: CCD
             CCD (or child of) object to be attached.
             Could be a delayed
-           
+
         ccdid: int or None
             id of the ccd.
-        
+
         Returns
         -------
         None
@@ -2438,11 +2438,11 @@ class FocalPlane(Image, _Collection_):
         if "dask" in str( type(ccd) ):
             self._use_dask = True
             self.ccds[ccdid] = ccd
-            
+
         else:
             if ccdid is None:
                 ccdid = ccd.ccdid
-                
+
             self.ccds[ccdid] = ccd
             self._use_dask  = ccd.use_dask
 
@@ -2464,16 +2464,16 @@ class FocalPlane(Image, _Collection_):
         -------
         list
             results of what called on each quadrant (1->16)
-        """        
+        """
         return self._call_down(what, *args, **kwargs)
-    
+
     def call_quadrants(self, what, *args, **kwargs):
-        """ run the given input on quadrants 
+        """ run the given input on quadrants
 
         Parameters
         ----------
         what: str
-            method or attribute of quadrants or anything 
+            method or attribute of quadrants or anything
             accessing through quadrant.get_value()
 
         *args goes to each quadrant.what() if method
@@ -2493,16 +2493,16 @@ class FocalPlane(Image, _Collection_):
             kwargs["key"] = what
             what = "get_value"
             is_func = True
-            
+
         if is_func: # is func ?
             return [getattr(q, what)(*args, **kwargs)
                         for ccdid, ccd in self.ccds.items()
                         for qid, q in ccd.quadrants.items()]
-        
+
         return [getattr(q, what)
                     for ccdid, ccd in self.ccds.items()
                     for qid, q in ccd.quadrants.items()]
-    
+
     # -------- #
     #  GETTER  #
     # -------- #
@@ -2547,10 +2547,10 @@ class FocalPlane(Image, _Collection_):
 
         if ccd_coef is None:
             ccd_coef = np.ones(16)
-            
+
         elif (size:= len(ccd_coef)) != 16:
             raise ValueError(f"size of ccd_coef must be 16. {size} given.")
-        
+
         # Merge quadrants of the 16 CCDs
         prop = {**dict(rebin=rebin), **kwargs}
 
@@ -2563,21 +2563,21 @@ class FocalPlane(Image, _Collection_):
                                                    self.get_ccd(1).get_data(**prop)*ccd_coef[0]
                                                   ),
                                                     axis=1)
-            
+
             line_2 = getattr(npda, "concatenate")((self.get_ccd(8).get_data(**prop)*ccd_coef[7],
                                                    self.get_ccd(7).get_data(**prop)*ccd_coef[6],
                                                    self.get_ccd(6).get_data(**prop)*ccd_coef[5],
                                                    self.get_ccd(5).get_data(**prop)*ccd_coef[4]
                                                   ),
                                                     axis=1)
-            
+
             line_3 = getattr(npda, "concatenate")((self.get_ccd(12).get_data(**prop)*ccd_coef[11],
                                                    self.get_ccd(11).get_data(**prop)*ccd_coef[10],
                                                    self.get_ccd(10).get_data(**prop)*ccd_coef[9],
                                                    self.get_ccd( 9).get_data(**prop)*ccd_coef[8]
                                                    ),
                                                     axis=1)
-            
+
             line_4 = getattr(npda, "concatenate")((self.get_ccd(16).get_data(**prop)*ccd_coef[15],
                                                    self.get_ccd(15).get_data(**prop)*ccd_coef[14],
                                                    self.get_ccd(14).get_data(**prop)*ccd_coef[13],
@@ -2587,7 +2587,7 @@ class FocalPlane(Image, _Collection_):
 
             mosaic = getattr(npda, "concatenate")( (line_1, line_2, line_3, line_4),
                                                     axis=0)
-            
+
         else:
             line_1 = getattr(npda, "concatenate")((self.get_ccd(4).get_data(**prop)*ccd_coef[3],
                                                     da.ones(self._get_datagap("columns", rebin=rebin))*np.nan,
@@ -2598,7 +2598,7 @@ class FocalPlane(Image, _Collection_):
                                                    self.get_ccd(1).get_data(**prop)*ccd_coef[0],
                                                        ),
                                                     axis=1)
-            
+
             line_2 = getattr(npda, "concatenate")((self.get_ccd(8).get_data(**prop)*ccd_coef[7],
                                                     da.ones(self._get_datagap("columns", rebin=rebin))*np.nan,
                                                    self.get_ccd(7).get_data(**prop)*ccd_coef[6],
@@ -2608,7 +2608,7 @@ class FocalPlane(Image, _Collection_):
                                                    self.get_ccd(5).get_data(**prop)*ccd_coef[4]
                                                     ),
                                                     axis=1)
-            
+
             line_3 = getattr(npda, "concatenate")((self.get_ccd(12).get_data(**prop)*ccd_coef[11],
                                                     da.ones(self._get_datagap("columns", rebin=rebin))*np.nan,
                                                    self.get_ccd(11).get_data(**prop)*ccd_coef[10],
@@ -2618,7 +2618,7 @@ class FocalPlane(Image, _Collection_):
                                                    self.get_ccd(9).get_data(**prop)*ccd_coef[8]
                                                        ),
                                                     axis=1)
-            
+
             line_4 = getattr(npda, "concatenate")((self.get_ccd(16).get_data(**prop)*ccd_coef[15],
                                                    da.ones(self._get_datagap("columns", rebin=rebin))*np.nan,
                                                    self.get_ccd(15).get_data(**prop)*ccd_coef[14],
@@ -2628,7 +2628,7 @@ class FocalPlane(Image, _Collection_):
                                                    self.get_ccd(13).get_data(**prop)*ccd_coef[12]
                                                     ),
                                                     axis=1)
-            
+
             size_shape = self._get_datagap("rows", rebin=rebin)[0]
             mosaic = getattr(npda, "concatenate")((line_1,
                                                    da.ones(
@@ -2649,10 +2649,10 @@ class FocalPlane(Image, _Collection_):
     # -------- #
     #  PLOTS   #
     # -------- #
-    def show_footprint(self, values="id", ax=None, 
+    def show_footprint(self, values="id", ax=None,
                            level="quadrant", cmap="coolwarm",
-                           vmin=None, vmax=None, 
-                           incl_ids=True, in_deg=True, 
+                           vmin=None, vmax=None,
+                           incl_ids=True, in_deg=True,
                            **kwargs):
         """ illustrate the image footprint
 
@@ -2660,10 +2660,10 @@ class FocalPlane(Image, _Collection_):
         ----------
         values: str, None, array, dict, pandas.Series
             values to be displaid as facecolor in the image.
-            - str: understood as a `level` properties 
+            - str: understood as a `level` properties
                    (using call_quadrants or call_ccds)
                    Special case: 'id' means:
-                   - ccdid if level='ccd' 
+                   - ccdid if level='ccd'
                    - rcid if level='quadrant
             - None: (or 'None') no facecolor (just edge)
             - array: value to be displaid. Size must match that
@@ -2676,12 +2676,12 @@ class FocalPlane(Image, _Collection_):
             axes where to draw the plot
 
         level: str
-            'ccd' (16) or 'quadrant' (64) 
+            'ccd' (16) or 'quadrant' (64)
 
         cmap: str or matplotlib's cmap
-            colormap 
+            colormap
 
-        vmin, vmax: 
+        vmin, vmax:
             boundaries for the colormap
 
         incl_ids: bool
@@ -2690,9 +2690,9 @@ class FocalPlane(Image, _Collection_):
 
         in_deg: bool
             should the footprint be shown in deg (True) or
-            in arcsec (False) ? 
+            in arcsec (False) ?
             note: 1 pixel ~ 1 arcsec
-        
+
         **kwargs goes to matplotlib.patches.Polygon
 
         Returns
@@ -2702,7 +2702,7 @@ class FocalPlane(Image, _Collection_):
         import matplotlib.pyplot as plt
         from matplotlib.patches import Polygon
         from matplotlib.colors import Normalize
-        
+
         # -------
         # level
         if level == "ccd":
@@ -2753,16 +2753,16 @@ class FocalPlane(Image, _Collection_):
         elif values is not None:
             # reindex
             values = pandas.Series(values).reindex( np.arange(nimages) ).values
-        
+
         if values is not None:
-            if vmin is None: 
+            if vmin is None:
                 vmin = np.nanmin(values)
-            if vmax is None: 
+            if vmax is None:
                 vmax = np.nanmax(values)
             norm = Normalize(vmin=vmin, vmax=vmax)
 
 
-        # using center and corner as debug, center could be derived from corners. 
+        # using center and corner as debug, center could be derived from corners.
         centers = np.stack(call_func("get_center", system="uv")) * coef
         corners = np.stack(call_func("get_corners", system="uv")) * coef
         ids = call_func(id_) # for labels
@@ -2776,7 +2776,7 @@ class FocalPlane(Image, _Collection_):
                 prop["lw"] = 1
                 prop["edgecolor"] = "0.7"
             else:
-                facecolor = cmap(norm(value_))                
+                facecolor = cmap(norm(value_))
 
             p = Polygon(corners_, facecolor=facecolor, **{**prop, **kwargs})
             ax.add_patch(p)
@@ -2795,10 +2795,10 @@ class FocalPlane(Image, _Collection_):
         ax.tick_params(labelsize="small", labelcolor="0.7", color="0.7")
 
         return fig
-    
+
     # =============== #
     #  Properties     #
-    # =============== #    
+    # =============== #
     @property
     def ccds(self):
         """ dictionary of the ccds {ccdid:CCD, ...}"""
@@ -2816,18 +2816,18 @@ class FocalPlane(Image, _Collection_):
     def _images(self):
         """ Internal property for _Collection_ methods """
         return list( self.ccds.values() )
-    
+
     @property
     def filenames(self):
         """ list of the filename of the different quadrants constituing the data. """
         return self.call_quadrants("filename")
-    
+
     @property
     def filepaths(self):
         """ list of the filename of the different quadrants constituing the data. """
         return self.call_quadrants("filepath")
 
-    
+
     @classproperty
     def shape_full(cls):
         """ shape with gap"""
@@ -2848,7 +2848,7 @@ class FocalPlane(Image, _Collection_):
     def qshape(cls):
         """ """
         return cls._ccdclass.qshape
-    
+
     # family
     @classproperty
     def _ccdclass(cls):
@@ -2856,7 +2856,7 @@ class FocalPlane(Image, _Collection_):
         if type( cls._CCDCLASS ) is str:
             try: # from this .py
                 return eval( cls._CCDCLASS )
-            except: # from the library 
+            except: # from the library
                 exec(f"from .__init__ import {cls._CCDCLASS}")
                 return eval( cls._CCDCLASS )
 

--- a/ztfimg/raw.py
+++ b/ztfimg/raw.py
@@ -305,7 +305,7 @@ class RawQuadrant( Quadrant ):
                      rebin=None, rebin_stat="nanmean",
                      reorder=True,
                      overscan_prop={}, **kwargs):
-        """ get the image data.
+        """get the image data.
 
         returned data can be affected by different effects.
 
@@ -319,8 +319,11 @@ class RawQuadrant( Quadrant ):
         corr_nl: bool
             Should data be corrected for non-linearity
 
-        corr_pocket: bool
-            Should data be corrected for the pocket effect ?
+        corr_pocket: bool or dict
+            Should data be corrected for the pocket effect ? If a dict,
+            provides explicit parameters for pocket effect correction, the dict
+            is (str: float) and must contains the following keys: alpha, cmax,
+            beta, nmax. See ztfsensors.pocket.PocketModel for details.
 
         rebin: int, None
             Shall the data be rebinned by square of size `rebin` ?
@@ -349,6 +352,7 @@ class RawQuadrant( Quadrant ):
         -------
         2d-array
             numpy or dask array
+
         """
         format_ = "raw" # ordering format
 
@@ -392,9 +396,18 @@ class RawQuadrant( Quadrant ):
             format_ = "read"
             n_overscan = self.overscan.shape[1] # overscan pixels
 
-            pockelconfig = pocket.get_config(self.ccdid, self.qid).values[0]
-            pockemodel = pocket.PocketModel(**pockelconfig)
-            data_and_overscan = correct_pixels(pockemodel, data_, n_overscan=n_overscan)
+            if isinstance(corr_pocket, dict):
+                # pocket effect parameters are given explicitely, ensure the
+                # expected values are here
+                if missing := (set(("cmax", "nmax", "alpha", "beta")) - corr_pocket.keys()):
+                    raise ValueError(f"pocket effect correction parameters are missing: {', '.join(missing)}")
+                if extra := (set(corr_pocket.keys()) - set(("cmax", "nmax", "alpha", "beta"))):
+                    warnings.warn(f"ignoring extra parameters given to corr_pocket: {', '.join(extra)}")
+                pocket_config = {k: float(corr_pocket[k]) for k in ("cmax", "nmax", "alpha", "beta")}
+            else:
+                pocket_config = pocket.get_config(self.ccdid, self.qid).values[0]
+            pocket_model = pocket.PocketModel(**pocket_config)
+            data_and_overscan = correct_pixels(pocket_model, data_, n_overscan=n_overscan)
             data_ = data_and_overscan[:,:-n_overscan]
 
         # ------------ #

--- a/ztfimg/raw.py
+++ b/ztfimg/raw.py
@@ -21,12 +21,12 @@ class RawQuadrant( Quadrant ):
     # "family"
     _CCDCLASS = "RawCCD"
     _FocalPlaneCLASS = "RawFocalPlane"
-    
+
     def __init__(self, data=None, header=None, overscan=None):
-        """ 
+        """
         See also
         --------
-        from_filename: load the instance given a filename 
+        from_filename: load the instance given a filename
         from_data: load the instance given its data (and header)
         """
         # Add the overscan to the __init__
@@ -39,7 +39,7 @@ class RawQuadrant( Quadrant ):
     def _read_overscan(cls, filepath, ext, use_dask=True, persist=False):
         """ assuming fits format. """
         from astropy.io.fits import getdata
-        
+
         if use_dask:
             overscan = da.from_delayed(dask.delayed(getdata)(filepath, ext=ext+4),
                                             shape=cls.SHAPE_OVERSCAN, dtype="float32")
@@ -47,13 +47,13 @@ class RawQuadrant( Quadrant ):
                 overscan = overscan.persist()
         else:
             overscan = getdata(filepath, ext=ext+4)
-            
-        return overscan            
+
+        return overscan
 
     @classmethod
     def from_data(cls, data, header=None, overscan=None, **kwargs):
-        """ Instanciate this class given data. 
-        
+        """ Instanciate this class given data.
+
         Parameters
         ----------
         data: numpy.array or dask.array]
@@ -76,7 +76,7 @@ class RawQuadrant( Quadrant ):
         use_dask = "dask" in str( type(data))
         return super().from_data(data, header=header, overscan=overscan,
                                  **kwargs)
-    
+
     @classmethod
     def from_filename(cls, filename, qid,
                           as_path=True,
@@ -89,18 +89,18 @@ class RawQuadrant( Quadrant ):
         ----------
         filename: str
             fullpath or filename or the file to load. This must be a raw ccd file.
-            If a filename is given, set as_path=False, then ztfquery.get_file() 
+            If a filename is given, set as_path=False, then ztfquery.get_file()
             will be called to grab the file for you (and download it if necessary)
-            
+
         qid: int
             quadrant id. Which quadrant to load from the input raw image ?
-            
+
         as_path: bool
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
-        
+
         use_dask: bool
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool
@@ -114,9 +114,9 @@ class RawQuadrant( Quadrant ):
 
         Returns
         -------
-        class instance     
+        class instance
         """
-        # - guessing format        
+        # - guessing format
         if qid not in [1,2,3,4]:
             raise ValueError(f"qid must be 1,2, 3 or 4 {qid} given")
 
@@ -130,11 +130,11 @@ class RawQuadrant( Quadrant ):
         header = cls._read_header(filepath, ext=qid, use_dask=dask_header, persist=persist)
         # and overscan
         overscan = cls._read_overscan(filepath, ext=qid, use_dask=use_dask, persist=persist)
-        
+
         this = cls(data, header=header, overscan=overscan, **kwargs)
         this._qid = qid
         this._filename = filename
-        this._filepath = filepath        
+        this._filepath = filepath
         this._meta = meta
         return this
 
@@ -152,7 +152,7 @@ class RawQuadrant( Quadrant ):
             rcid of the given quadrant
 
         use_dask: bool
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool
@@ -164,22 +164,22 @@ class RawQuadrant( Quadrant ):
         Returns
         -------
         class instance
-        
+
         """
         from ztfquery.io import filefracday_to_local_rawdata
         ccdid, qid = rcid_to_ccdid_qid(rcid)
-        
+
         filename = filefracday_to_local_rawdata(filefracday, ccdid=ccdid)
-        
+
         if len(filename)==0:
             raise IOError(f"No local raw data found for filefracday: {filefracday} and ccdid: {ccdid}")
-        
+
         if len(filename)>1:
             raise IOError(f"Very strange: several local raw data found for filefracday: {filefracday} and ccdid: {ccdid}", filename)
-        
+
         return cls.from_filename(filename[0], qid=qid, use_dask=use_dask,
                                  as_path=False, persist=persist, **kwargs)
-    
+
     @staticmethod
     def read_rawfile_header(filepath, qid, grab_imgkeys=True):
         """ reads the filename's header and returns it as a pandas.DataFrame
@@ -201,10 +201,10 @@ class RawQuadrant( Quadrant ):
         `pandas.DataFrame`
             the header
         """
-        imgkeys = ["EXPTIME", "IMGTYPE", "PIXSCALE", "THETA_X", "THETA_Y", "INST_ROT", 
+        imgkeys = ["EXPTIME", "IMGTYPE", "PIXSCALE", "THETA_X", "THETA_Y", "INST_ROT",
                    "FILTER", "OBSJD", "RAD", "DECD", "TELRA","TELDEC", "AZIMUTH","ELVATION",
                    ]
-        
+
         if "_f.fits" in filepath:
             imgkeys += ["ILUM_LED", "ILUMWAVE", "ILUMPOWR"]
 
@@ -213,7 +213,7 @@ class RawQuadrant( Quadrant ):
             imgheader = fits.getheader(filepath, ext=0)
             for key in imgkeys:
                 header.set(key, imgheader.get(key), imgheader.comments[key])
-            
+
         del imgheader
         # DataFrame to be able to dask it.
         return pandas.DataFrame( pandas.Series(header) )
@@ -223,9 +223,9 @@ class RawQuadrant( Quadrant ):
     # -------- #
     def set_overscan(self, overscan):
         """ set the overscan image.
-        
+
         = It is unlikely you need to use that directly. =
-        
+
         Parameters
         ----------
         overscan: 2d-array
@@ -236,7 +236,7 @@ class RawQuadrant( Quadrant ):
         None
         """
         self._overscan = overscan
-                    
+
     # -------- #
     # GETTER   #
     # -------- #
@@ -249,10 +249,10 @@ class RawQuadrant( Quadrant ):
         Parameters
         ----------
         stacked: bool
-            Format of the returned data: 
-            - True: np.hstack([data, overscan]) 
+            Format of the returned data:
+            - True: np.hstack([data, overscan])
             - False: [data, overscan]
-            
+
         Returns
         data and overscan
             array, (see stacked)
@@ -262,11 +262,11 @@ class RawQuadrant( Quadrant ):
         overscan = self._reorder_data(self.overscan, in_="raw", out_="read")
         if stacked:
             return self._np_backend.hstack([data, overscan])
-            
+
         return data, overscan
 
     def _reorder_data(self, data, in_="raw", out_="sky"):
-        """ 
+        """
         in_ and out_ could be:
         - raw: as stored in the raw image
         - sky: as observed in the sky
@@ -274,12 +274,12 @@ class RawQuadrant( Quadrant ):
         """
         if in_ == out_: # nothing to do
             return data
-        
+
         # raw <-> sky
         elif (in_ == "raw" and out_ == "sky") or (in_ == "sky" and out_ == "raw"):
             data = data[::-1,::-1]
 
-        # raw <-> read            
+        # raw <-> read
         elif (in_ == "raw" and out_ == "read") or (in_ == "read" and out_ == "raw"):
             if self.qid in [2, 3]:
                 data = data[:,::-1]
@@ -287,17 +287,17 @@ class RawQuadrant( Quadrant ):
             # bottom for quadrants 3 and 4
             if self.qid in [3, 4]:
                 data = data[::-1,:]
-                
+
         elif (in_ == "sky" and out_ == "read") or (in_ == "read" and out_ == "sky"):
             data_raw = self._reorder_data(data, in_=in_, out_="raw")
             data = self._reorder_data(data_raw, in_="raw", out_=out_)
-            
+
         else:
             warnings.warn("cannot parse the input in_ and out_, nothing happens")
-            
+
         return data
-        
-        
+
+
     def get_data(self,
                      corr_overscan=False,
                      corr_nl=False,
@@ -305,15 +305,15 @@ class RawQuadrant( Quadrant ):
                      rebin=None, rebin_stat="nanmean",
                      reorder=True,
                      overscan_prop={}, **kwargs):
-        """ get the image data. 
+        """ get the image data.
 
         returned data can be affected by different effects.
-        
+
         Parameters
         ----------
         corr_overscan: bool
             Should the data be corrected for overscan
-            (if both corr_overscan and corr_nl are true, 
+            (if both corr_overscan and corr_nl are true,
             nl is applied first)
 
         corr_nl: bool
@@ -321,7 +321,7 @@ class RawQuadrant( Quadrant ):
 
         corr_pocket: bool
             Should data be corrected for the pocket effect ?
-            
+
         rebin: int, None
             Shall the data be rebinned by square of size `rebin` ?
             None means no rebinning.
@@ -336,15 +336,15 @@ class RawQuadrant( Quadrant ):
             For instance, if rebin=4 and rebin_stat = median
             the median of a 4x4 pixel will be used to form a new pixel.
             The dimension of the final image will depend on rebin.
-        
+
         reorder: bool
             Should the data be re-order to match the actual north-up.
             (leave to True if not sure)
-            
+
         overscan_prop: [dict] -optional-
             kwargs going to get_overscan()
             - > e.g. userange=[10,20], stackstat="nanmedian", modeldegree=5,
-            
+
         Returns
         -------
         2d-array
@@ -355,24 +355,24 @@ class RawQuadrant( Quadrant ):
         # ------------ #
         # Data access  #
         # ------------ #
-        
+
         # rebin is made later on.
         if not corr_pocket:
             data_ = super().get_data(rebin=None, reorder=False, **kwargs)
-            
+
         else: # pocket effect need to overscan attached | this changes the "format".
             data_ = self.get_data_and_overscan(stacked=True)
             format_ = "read" # ordering format
-            
+
         # ------------ #
         # processing   #
         # ------------ #
         # remove overscan
         if corr_overscan:
             os_model = self.get_overscan( **{**dict(which="model"), **overscan_prop} )
-            data_ -= os_model[:,None]            
+            data_ -= os_model[:,None]
 
-        # correct non-linearity                        
+        # correct non-linearity
         if corr_nl:
             a, b = self.get_nonlinearity_corr()
             data_ /= (a*data_**2 + b*data_ + 1)
@@ -391,12 +391,12 @@ class RawQuadrant( Quadrant ):
             data_ = self._reorder_data(data_, in_=format_, out_="read") # make sure it is the good format
             format_ = "read"
             n_overscan = self.overscan.shape[1] # overscan pixels
-            
+
             pockelconfig = pocket.get_config(self.ccdid, self.qid).values[0]
             pockemodel = pocket.PocketModel(**pockelconfig)
             data_and_overscan = correct_pixels(pockemodel, data_, n_overscan=n_overscan)
             data_ = data_and_overscan[:,:-n_overscan]
-        
+
         # ------------ #
         #  Formating   #
         # ------------ #
@@ -412,8 +412,8 @@ class RawQuadrant( Quadrant ):
 
     def get_nonlinearity_corr(self):
         """ looks in the raw.NONLINEARITY_TABLE the the entry corresponding to the quadrant's rcid
-        and returns the a and b parameters. 
-        
+        and returns the a and b parameters.
+
         raw data should be corrected as such:
         ```
         data_corr = data/(a*data**2 + b*data +1)
@@ -427,57 +427,57 @@ class RawQuadrant( Quadrant ):
         NONLINEARITY_TABLE = get_nonlinearity_table(obsdate)
 
         return NONLINEARITY_TABLE.loc[self.rcid][["a","b"]].astype("float").values
-        
+
     def get_overscan(self, which="data", sigma_clipping=3,
                          userange=[20,30], stackstat="nanmedian",
                          modeldegree=3, specaxis=1,
                          corr_overscan=False, corr_nl=False):
-        """ 
-        
+        """
+
         Parameters
         ----------
         which: str
-            There are different format. 
+            There are different format.
             - data and raw are 2d images:
                - 'raw' are the overscan as stored
-               - 'data' re-order the data, that is, first overscan left and north up 
+               - 'data' re-order the data, that is, first overscan left and north up
                         matching get_data(reorder=True).
 
             could be:
-              - 'raw': as stored | 
-                      most likely you want 'data' as it includes re-ordering 
+              - 'raw': as stored |
+                      most likely you want 'data' as it includes re-ordering
                       i.e. [:,0] is the first overscan independently of the quadrant
-              - 'data': raw re-ordered and within userange (if given). 
+              - 'data': raw re-ordered and within userange (if given).
               - 'spec': vertical or horizontal profile of the overscan
               see stackstat (see specaxis). Clipping is applied at that time (if clipping=True)
               - 'model': polynomial model of spec
-            
+
         clipping: bool
             Should clipping be applied to remove the obvious flux excess.
             This clipping is made using median statistics (median and 3*nmad)
-            
+
         specaxis: int
-            axis along which you are doing the median 
-            = Careful: after userange applied = 
+            axis along which you are doing the median
+            = Careful: after userange applied =
             - axis: 1 (default) -> horizontal overscan data spectrum (~3000 pixels)
             - axis: 0 -> vertical stack of the overscan (~30 pixels)
             (see stackstat for stacking statistic (mean, median etc)
-            
+
         stackstat: str
             numpy method to use to converting data into spec
-            
+
         userange: 2d-array
             = ignored is which != data or raw =
-            start and end of overscan data to be considered. 
-                        
+            start and end of overscan data to be considered.
+
         corr_overscan: bool
-            = only if which is raw or data = 
+            = only if which is raw or data =
             Should the data be corrected for overscan
-            (if both corr_overscan and corr_nl are true, 
+            (if both corr_overscan and corr_nl are true,
             nl is applied first)
 
         corr_nl: bool
-            = only if which is raw or data = 
+            = only if which is raw or data =
             Should data be corrected for non-linearity
 
         Returns
@@ -489,8 +489,8 @@ class RawQuadrant( Quadrant ):
         To get the raw overscan vertically stacked spectra, using mean statistic do:
         get_overscan('spec', userange=None, specaxis=0, stackstat='nanmean')
         """
-            
-        # raw (or data, that is cleaned raw)            
+
+        # raw (or data, that is cleaned raw)
         if which in ["raw", "data"]:
             data = self.overscan.copy()
             if which == "data":
@@ -500,20 +500,20 @@ class RawQuadrant( Quadrant ):
                     data = data[::-1, ::-1]
                 else:
                     data = data[::-1, :]
-                    
+
             if userange is not None:
                 data = data[:, userange[0]:userange[1]]
-                    
+
             # correct for non linearity
             if corr_nl:
                 a, b = self.get_nonlinearity_corr()
                 data /= (a*data**2 + b*data + 1)
-                
+
             # correct for overscan model
             if corr_overscan:
                 os_model = self.get_overscan(which="model")
-                data -= os_model[:,None]            
-                
+                data -= os_model[:,None]
+
             return data
 
         # Spectrum or Model
@@ -524,24 +524,24 @@ class RawQuadrant( Quadrant ):
                                             sigma_clipping=sigma_clipping,
                                             stackstat=stackstat,
                                             axis=specaxis)
-        
+
         if which == "model":
             spec = self.get_overscan(which = "spec", userange=userange,
-                                        sigma_clipping=sigma_clipping,                                         
+                                        sigma_clipping=sigma_clipping,
                                         stackstat=stackstat,
                                         specaxis=specaxis)
             # dask
-            if self._use_dask:                
+            if self._use_dask:
                 d_ = dask.delayed(fit_polynome)(np.arange( len(spec) ), spec, degree=modeldegree)
                 return da.from_delayed(d_, shape=spec.shape, dtype="float32")
             # numpy
             return fit_polynome(np.arange(len(spec)), spec, degree=modeldegree)
-        
-        raise ValueError(f'which should be "raw", "data", "spec", "model", {which} given')    
+
+        raise ValueError(f'which should be "raw", "data", "spec", "model", {which} given')
 
     @classmethod
-    def _get_overscan_spec_(cls, data, 
-                            sigma_clipping=None, stackstat="nanmedian", 
+    def _get_overscan_spec_(cls, data,
+                            sigma_clipping=None, stackstat="nanmedian",
                             axis=1):
         """ compute the overscan spectrum from a input overscan 2d-data
 
@@ -568,14 +568,14 @@ class RawQuadrant( Quadrant ):
 
         if "dask" in str( type(data) ):
             d_spec = dask.delayed(cls._get_overscan_spec_)(data,
-                                                        sigma_clipping=sigma_clipping, 
+                                                        sigma_clipping=sigma_clipping,
                                                         stackstat=stackstat,
                                                         axis=axis)
 
             new_shape = list(data.shape)
             _ = new_shape.pop(axis)
             new_shape = tuple(new_shape)
-            
+
             spec = da.from_delayed(d_spec, shape=new_shape, dtype=data.dtype)
             return spec
 
@@ -598,7 +598,7 @@ class RawQuadrant( Quadrant ):
 
     def get_lastdata_firstoverscan(self, n=1, corr_overscan=False, corr_nl=False, **kwargs):
         """ get the last data and the first overscan columns
-        
+
         Parameters
         ----------
         n: int
@@ -608,7 +608,7 @@ class RawQuadrant( Quadrant ):
 
         Returns
         -------
-        list 
+        list
             (2, n-row) data (last_data, first_overscan)
         """
         # for reorder to make sure they are on the "normal" way.
@@ -620,7 +620,7 @@ class RawQuadrant( Quadrant ):
         # q2 | q1
         # -------
         # q3 | q4
-        
+
         if self.qid in [1,4]: # top-right, bottom-righ
             last_data = data[:,:n] # 0 = leftmost part of the ccd
             first_overscan = overscan[:,:n]
@@ -628,14 +628,14 @@ class RawQuadrant( Quadrant ):
             # [:,::-1] means first, second, etc.
             last_data = data[:,-n:][:,::-1] # rightmost part of the ccd
             first_overscan = overscan[:,-n:][:,::-1]
-            
+
         return last_data.squeeze(), first_overscan.squeeze()
 
-    
+
     def get_sciimage(self, use_dask=None, **kwargs):
         """ get the Science image corresponding to this raw image
-        
-        This uses ztfquery to parse the filename and set up the correct 
+
+        This uses ztfquery to parse the filename and set up the correct
         science image filename path.
 
         Parameters
@@ -651,14 +651,14 @@ class RawQuadrant( Quadrant ):
         """
         if use_dask is None:
             use_dask = self.use_dask
-            
+
         from ztfquery.buildurl import get_scifile_of_filename
 
         from .science import ScienceQuadrant
-        # 
+        #
         filename = get_scifile_of_filename(self.filename, qid=self.qid, source="local")
         return ScienceQuadrant.from_filename(filename, use_dask=use_dask, as_path=False, **kwargs)
-    
+
     # -------- #
     # PLOTTER  #
     # -------- #
@@ -675,7 +675,7 @@ class RawQuadrant( Quadrant ):
         fig
         """
         import matplotlib.pyplot as mpl
-        
+
         if ax is None:
             fig = mpl.figure(figsize=[4,6])
             ax  = fig.add_axes([0.15, 0.100, 0.58, 0.75])
@@ -683,10 +683,10 @@ class RawQuadrant( Quadrant ):
             axm = fig.add_axes([0.15, 0.865, 0.58, 0.10])
         else:
             fig = ax.figure
-            
+
         prop = dict(origin="lower", cmap="cividis", aspect="auto")
         im = ax.imshow(self.get_overscan(which), **{**prop,**kwargs})
-        
+
         if axs is not None:
             spec = self.get_overscan("spec")
             model = self.get_overscan("model")
@@ -694,18 +694,18 @@ class RawQuadrant( Quadrant ):
             axs.plot(model, np.arange(len(spec)))
             axs.set_yticks([])
             axs.set_ylim(*ax.get_ylim())
-        
+
         if axm is not None:
             spec_to = self.get_overscan("spec", userange=None, specaxis=0)
             axm.plot(np.arange(len(spec_to)), spec_to)
             axm.set_xticks([])
             axm.set_xlim(*ax.get_xlim())
-            
+
         if colorbar:
             fig.colorbar(im, cax=cax, ax=ax)
-            
+
         return fig
-        
+
     # =============== #
     #  Properties     #
     # =============== #
@@ -713,29 +713,29 @@ class RawQuadrant( Quadrant ):
     def _np_backend(self):
         """ """
         return da if self._use_dask else np
-    
+
     @property
     def shape_overscan(self):
         """ shape of the raw overscan data """
         return self.SHAPE_OVERSCAN
-    
+
     @property
     def overscan(self):
         """ """
         if not hasattr(self, "_overscan"):
             return None
         return self._overscan
-            
+
     @property
     def qid(self):
         """ quadrant (amplifier of the ccd) id (1->4) """
         return self._qid if hasattr(self, "_qid") else (self.get_value("AMP_ID")+1)
-    
+
     @property
     def rcid(self):
         """ quadrant (within the focal plane) id (0->63) """
         return 4*(self.ccdid - 1) + self.qid - 1
-    
+
     @property
     def gain(self):
         """ gain [adu/e-] """
@@ -745,21 +745,21 @@ class RawQuadrant( Quadrant ):
     def darkcurrent(self):
         """ Dark current [e-/s]"""
         return self.get_value("DARKCUR", None, attr_ok=False) # avoid loop
-    
+
     @property
     def readnoise(self):
         """ read-out noise [e-] """
         return self.get_value("READNOI", None, attr_ok=False) # avoid loop
-        
-        
+
+
 class RawCCD( CCD ):
 
     _COLLECTION_OF = RawQuadrant
     # "family"
     _QUADRANTCLASS = "RawQuadrant"
-    _FocalPlaneCLASS = "RawFocalPlane"    
-    
-    
+    _FocalPlaneCLASS = "RawFocalPlane"
+
+
     @classmethod
     def from_filename(cls, filename, as_path=True, use_dask=False, persist=False, **kwargs):
         """ load the instance from the raw filename.
@@ -768,15 +768,15 @@ class RawCCD( CCD ):
         ----------
         filename: str
             fullpath or filename or the file to load.
-            If a filename is given, set as_path=False,  then ztfquery.get_file() 
+            If a filename is given, set as_path=False,  then ztfquery.get_file()
             will be called to grab the file for you (and download it if necessary)
-            
+
         as_path: bool
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
-        
+
         use_dask: bool, optional
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool, optional
@@ -785,20 +785,20 @@ class RawCCD( CCD ):
 
         **kwargs: goes to _QUADRANTCLASS.from_filename
 
-        
+
         Returns
         -------
-        class instance 
-        
+        class instance
+
         Examples
         --------
         Load a ztf image you know the name of but not the full path.
-        
+
         >>> rawccd = ztfimg.RawCCD.from_filename("ztf_20220704387176_000695_zr_c11_o.fits.fz", as_path=False)
         """
         qids = (1,2,3,4)
-        
-        quadrant_from_filename = cls._quadrantclass.from_filename            
+
+        quadrant_from_filename = cls._quadrantclass.from_filename
         quadrants = [quadrant_from_filename(filename,
                                             qid=qid,
                                             as_path=as_path,
@@ -806,35 +806,35 @@ class RawCCD( CCD ):
                                             persist=persist,
                                             **kwargs)
                          for qid in qids]
-            
+
         this = cls.from_quadrants(quadrants, qids=qids)
         this._filename = filename
         if as_path:
             this._filepath = filename
-            
+
         this._meta = io.parse_filename(filename)
         return this
 
     @classmethod
     def from_single_filename(cls, *args, **kwargs):
-        """ rawccd data have a single file. 
+        """ rawccd data have a single file.
 
         See also
         --------
         from_filename: load the instance given the raw filename
         """
         return cls.from_filename(*args, **kwargs)
-    
+
     @classmethod
     def from_filenames(cls, *args, **kwargs):
-        """ rawccd data have a single file. 
+        """ rawccd data have a single file.
 
         See also
         --------
         from_filename: load the instance given the raw filename
         """
         raise NotImplementedError("from_filenames does not exists. See from_filename")
-    
+
     @classmethod
     def from_filefracday(cls, filefracday, ccdid, use_dask=True, **kwargs):
         """ load the instance given a filefracday and the ccidid (ztf ID)
@@ -849,7 +849,7 @@ class RawCCD( CCD ):
             ccidid of the given ccd
 
         use_dask: bool
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool
@@ -861,7 +861,7 @@ class RawCCD( CCD ):
         Returns
         -------
         class instance
-        
+
         """
         from ztfquery.io import filefracday_to_local_rawdata
         filename = filefracday_to_local_rawdata(filefracday, ccdid=ccdid)
@@ -869,25 +869,25 @@ class RawCCD( CCD ):
             raise IOError(f"No local raw data found for filefracday: {filefracday} and ccdid: {ccdid}")
         if len(filename)>1:
             raise IOError(f"Very strange: several local raw data found for filefracday: {filefracday} and ccdid: {ccdid}", filename)
-        
+
         return cls.from_filename(filename[0], as_path=False, use_dask=use_dask, **kwargs)
 
 
 
     def get_sciimage(self, use_dask=None, qid=None, as_ccd=True, **kwargs):
         """ get the Science image corresponding to this raw image
-        
-        This uses ztfquery to parse the filename and set up the correct 
+
+        This uses ztfquery to parse the filename and set up the correct
         science image filename path.
 
         Parameters
         ----------
         use_dask: bool or None
             if None, this will use self.use_dask.
-            
+
         qid: int or None
             do you want a specific quadrant ?
-            
+
         as_ccd: bool
             = ignored if qid is not None =
             should this return a list of science quadrant (False)
@@ -907,7 +907,7 @@ class RawCCD( CCD ):
         from .science import ScienceQuadrant
         # Specific quadrant
         prop = {"as_path":False}
-        
+
         if qid is not None:
             filename = get_scifile_of_filename(self.filename, qid=qid, source="local")
             return ScienceQuadrant.from_filename(filename, use_dask=use_dask, **{**prop,**kwargs} )
@@ -916,24 +916,24 @@ class RawCCD( CCD ):
         filenames = get_scifile_of_filename(self.filename, source="local")
         quadrants = [ScienceQuadrant.from_filename(filename, use_dask=use_dask, **{**prop,**kwargs} )
                     for filename in filenames]
-        
+
         if as_ccd:
             from .science import ScienceCCD
             return ScienceCCD.from_quadrants(quadrants, qids=[1,2,3,4], **kwargs)
-        
+
         # If not, then list of science quadrants
         return quadrants
 
-    
+
 class RawFocalPlane( FocalPlane ):
     # INFORMATION || Numbers to be fine tuned from actual observations
-    # 15 µm/arcsec  (ie 1 arcsec/pixel) and using 
-    # 7.2973 mm = 487 pixel gap along rows (ie between columns) 
+    # 15 µm/arcsec  (ie 1 arcsec/pixel) and using
+    # 7.2973 mm = 487 pixel gap along rows (ie between columns)
     # and 671 pixels along columns.
     _COLLECTION_OF = RawCCD
     # family
     _CCDCLASS = "RawCCD"
-    
+
     @classmethod
     def from_filenames(cls, filenames, as_path=True,
                            use_dask=False, persist=False,
@@ -944,15 +944,15 @@ class RawFocalPlane( FocalPlane ):
         ----------
         filenames: list of str
             list of fullpath or filename or the ccd file to load.
-            If a filename is given, set as_path=False,  then ztfquery.get_file() 
+            If a filename is given, set as_path=False,  then ztfquery.get_file()
             will be called to grab the file for you (and download it if necessary)
-            
+
         as_path: bool
             Set this to true if the input file is not the fullpath but you need
             ztfquery.get_file() to look for it for you.
-        
+
         use_dask: bool, optional
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool, optional
@@ -960,11 +960,11 @@ class RawFocalPlane( FocalPlane ):
             should we use dask's persist() on data ?
 
         **kwargs: goes to _CCDCLASS.from_filename
-        
+
         Returns
         -------
-        class instance 
-        
+        class instance
+
         """
         this = cls()
         for file_ in filenames:
@@ -976,7 +976,7 @@ class RawFocalPlane( FocalPlane ):
         this._filenames = filenames
         if as_path:
             this._filepaths = filenames
-            
+
         return this
 
     @classmethod
@@ -990,7 +990,7 @@ class RawFocalPlane( FocalPlane ):
             ztfquery will fetch for the corresponding data.
 
         use_dask: bool
-            Should dask be used ? The data will not be loaded but delayed 
+            Should dask be used ? The data will not be loaded but delayed
             (dask.array)
 
         persist: bool
@@ -1002,17 +1002,17 @@ class RawFocalPlane( FocalPlane ):
         Returns
         -------
         class instance
-        
+
         """
         from ztfquery.io import filefracday_to_local_rawdata
         filenames = filefracday_to_local_rawdata(filefracday, ccdid="*")
         if len(filenames)==0:
             raise IOError(f"No local raw data found for filefracday: {filefracday}")
-        
+
         if len(filenames)>16:
             raise IOError(f"Very strange: more than 16 local raw data found for filefracday: {filefracday}", filenames)
-        
+
         if len(filenames)<16:
             warnings.warn(f"Less than 16 local raw data found for filefracday: {filefracday}")
-        
+
         return cls.from_filenames(filenames, use_dask=use_dask, **kwargs)


### PR DESCRIPTION
The parameter `corr_pocket` of `ztfimg.raw.RawQuadrant.get_data` can now be a dict or a bool. If a bool, the behavior is unchanged. If a dict, provides explicit parameters for pocket effect correction, the dict is `(str: float)` and must contains the following keys: alpha, cmax, beta, nmax.

(whitespaces removed by my editor)